### PR TITLE
Make SUPPRESSED not collide with WARN

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,13 +7,13 @@ logging-levels
 
 As projects get bigger, ``logging.debug()`` becomes the dumping
 ground for everything that your application is doing. This usually
-becomes so noisy that you can't really make sense of what you're 
-trying to debug. 
+becomes so noisy that you can't really make sense of what you're
+trying to debug.
 
-Although it is usually disabled in production, 
-sometimes you need to enable debug logging to -- you know -- actually
-debug something. But since *everything* is dumped there, it's too
-much of a mess to wade through.
+Although it is usually disabled in production, sometimes you need to
+enable debug logging to -- you know -- actually debug something. But
+since *everything* is dumped there, it's too much of a mess to wade
+through.
 
 To help with this, you can add extra logging levels. However, rarely
 are they added to projects and when they are, they're often incomplete.
@@ -58,18 +58,6 @@ Want to implicitly log exceptions with your fancy new log level?:
         # Will include exception in log
         log.dang('Something broke.')
 
-To help everyone standardize on some log levels, logging_levels
-has standards:
-
-.. code:: python
-
-    from logging_levels.standards import add_standards
-    import logging
-    add_standards(logging)
-
-    log.trace('Log every -- single -- detail')
-    log.verbose('Debug, but so much more')
-    log.suppressed('Warn a suppressed exception')        
 
 Project Loggers
 ---------------
@@ -100,6 +88,66 @@ project easily.
     from mylib import logging
     logging.error('Oops, broke something.')
 
+
+Standards
+---------
+
+To help everyone standardize on the same log levels, this library
+provides a function to add some missing severity levels defined by the
+the syslog protocol in `RFC-5424 <https://tools.ietf.org/html/rfc5424>`_.
+
+This library also introduces some additional debugging levels and a
+``SUPPRESSED`` level which is intended to be used for logging suppressed
+exceptions that you may want to log, but otherwise consider handled.
+
+Use the function ``add_standards`` to add the standard levels provided
+by logging-levels:
+
+.. code:: python
+
+    from logging_levels.standards import add_standards
+    import logging
+    add_standards(logging)
+
+    log.emergency('This aggression will not stand, man.')
+    log.alert('Oh no! Something happened!')
+    log.notice('FYI this other thing happened.')
+    log.verbose('Debug, but so much more')
+    log.trace('Log every -- single -- detail')
+    log.suppressed('Warn a suppressed exception')
+
+
+All levels after using ``add_standards`` will be (new levels are bolded):
+
++---------------+---------------+
+| Level         | Numeric Value |
++===============+===============+
+| **EMERGENCY** | **100**       |
++---------------+---------------+
+| **ALERT**     | **70**        |
++---------------+---------------+
+| CRITICAL      | 50            |
++---------------+---------------+
+| ERROR         | 40            |
++---------------+---------------+
+| **SUPPRESSED**| **31**        |
++---------------+---------------+
+| WARNING       | 30            |
++---------------+---------------+
+| **NOTICE**    | **25**        |
++---------------+---------------+
+| INFO          | 20            |
++---------------+---------------+
+| DEBUG         | 10            |
++---------------+---------------+
+| **VERBOSE**   |  **7**        |
++---------------+---------------+
+| **TRACE**     |  **5**        |
++---------------+---------------+
+| NOTSET        |  0            |
++---------------+---------------+
+
+
 Installing
 ----------
 
@@ -114,7 +162,7 @@ Install dev requirements:
 
 .. code-block:: console
 
-    pip install -r dev.requirements.txt
+    pip install -r test.requirements.txt
 
 Install project:
 

--- a/logging_levels/__init__.py
+++ b/logging_levels/__init__.py
@@ -1,5 +1,6 @@
 import sys
 
+
 class Level(object):
     """
     Represents a log level
@@ -12,11 +13,13 @@ class Level(object):
         self.level = level
         self.exceptions = exceptions
 
+
 def log_exceptions(level):
     """
     Shortcut to create a Level that logs exceptions
     """
     return Level(level, exceptions=True)
+
 
 def isolated_logging(**levels):
     """
@@ -54,9 +57,10 @@ def isolated_logging(**levels):
 
     return logging
 
+
 def add_log_level(exceptions=False, logging=None, **levels):
     """
-    Add additional log levels. 
+    Add additional log levels.
 
     :param logging: Logging module to use (default ``import logging``).
     :param exceptions: True to include exceptions by default with these log levels.
@@ -67,7 +71,7 @@ def add_log_level(exceptions=False, logging=None, **levels):
 
         add_log_level(TRACE=8, VERBOSE=9, exceptions=True)
         add_log_level(WTF=log_exceptions(1000))
-    """    
+    """
     if not logging:
         import logging
 
@@ -85,27 +89,29 @@ def add_log_level(exceptions=False, logging=None, **levels):
     # Now that error checking is out of way, register handlers
     for name, level in levels.items():
         include_exceptions = exceptions
-        if isinstance(level, Level):            
+        if isinstance(level, Level):
             include_exceptions = level.exceptions
             level = level.level
 
         _make_log_level(name, level, include_exceptions, logging)
 
+
 def _make_log_level(name, level, exceptions, logging):
     """
-    Create neccessary log levels, functions, and 
+    Create neccessary log levels, functions, and
     logging attributes for a new log level.
     """
     logging.addLevelName(level, name)
     setattr(logging, name, level)
 
     func_name = name.lower()
+
     def log(self, message, *args, **kws):
         if exceptions:
             # Include exceptions by default
             kws['exc_info'] = kws.get('exc_info', True)
 
-        self.log(level, message, *args, **kws) 
+        self.log(level, message, *args, **kws)
 
     log.__name__ = func_name
 

--- a/logging_levels/standards.py
+++ b/logging_levels/standards.py
@@ -13,21 +13,41 @@ Example::
 """
 from logging_levels import add_log_level
 
+
 def add_standards(logging):
     """
     Add standard log levels to ``logging`` module
     """
     add_log_level(
-        # Log debug details of constant changes
-        TRACE=5 , 
-        # Log debug with a little more chattyness
+        # From syslog: System is unusable.
+        # This level should not be used by applications.
+        EMERGENCY=100,
+
+        # From syslog: Should be corrected immediately.
+        # Loss of the primary ISP connection.
+        ALERT=70,
+
+        # From syslog: Events that are unusual, but not error conditions.
+        NOTICE=25,
+
+        # Log debug messages with a little more chattyness
         VERBOSE=7,
+
+        # Log debug details of constant changes
+        TRACE=5,
         logging=logging
     )
 
     # Log a suppressed exception at warning level
     add_log_level(
-        SUPPRESSED=logging.WARN,
-        exceptions=True, 
+        # We want this to be nearly the same as WARN, but we don't
+        # want to blow away the WARN log level name. If we used a
+        # level below WARN these suppressed exceptions would not be
+        # logged when setting the log level to WARN. Since we're
+        # deliberately trying to expose exceptions and such at this
+        # level we're choosing something right above the WARN level
+        # so that we don't collide and so that it still gets logged.
+        SUPPRESSED=logging.WARN + 1,
+        exceptions=True,
         logging=logging
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ except ImportError:
     # Python 3.x use io.StringIO but not in 2.x
     # because in 2.x io.StringIO expects unicodes
     from io import StringIO as Stream
-    
+
 
 @pytest.fixture(scope='function')
 def logging(request):
@@ -20,9 +20,9 @@ def logging(request):
     import logging
     sys.modules['logging'] = logging
 
-    def exit():        
+    def exit():
         loaded = sys.modules.get('logging', None)
-        if loaded == logging:            
+        if loaded == logging:
             # Remove so others don't use it
             del sys.modules['logging']
 
@@ -30,10 +30,11 @@ def logging(request):
 
     return logging
 
+
 @pytest.fixture
 def stream_log():
     """
-    Returns a function that will create a logger 
+    Returns a function that will create a logger
     for the specified logging module
     with a StringIO log handler and sets the format
     to "{levelname}:{message}".
@@ -48,12 +49,12 @@ def stream_log():
 
         log = logging.getLogger()
         log.setLevel(0)
-        for handler in log.handlers: 
+        for handler in log.handlers:
             log.removeHandler(handler)
-        log.addHandler(handler)    
-
+        log.addHandler(handler)
 
         ctx = {'pos': 0}
+
         def readlines():
             """
             Read one line from the log stream.
@@ -78,6 +79,7 @@ def stream_log():
         return log
     return make
 
+
 @pytest.fixture(scope='function')
 def log(logging, stream_log):
     """
@@ -85,4 +87,4 @@ def log(logging, stream_log):
     with a StringIO log handler and sets the format
     to "{levelname}:{message}".
     """
-    return stream_log(logging)    
+    return stream_log(logging)

--- a/tests/test_level_standards.py
+++ b/tests/test_level_standards.py
@@ -1,25 +1,37 @@
-import sys
-from logging_levels.standards import add_standards    
+from logging_levels.standards import add_standards
+
 
 def test_level_standards(logging, log):
     """
-    Ensure that the standard log levels work 
+    Ensure that the standard log levels work
     """
     add_standards(logging)
-    
-    assert logging.TRACE == 5
-    assert logging.VERBOSE == 7
 
+    assert logging.EMERGENCY == 100
+    log.emergency("Emergency!")
+    assert log.last() == ['EMERGENCY', "Emergency!"]
+
+    assert logging.ALERT == 70
+    log.alert("Alert!")
+    assert log.last() == ['ALERT', "Alert!"]
+
+    assert logging.NOTICE == 25
+    log.notice("FYI")
+    assert log.last() == ['NOTICE', "FYI"]
+
+    assert logging.VERBOSE == 7
     log.verbose("I've said too much")
     assert log.last() == ['VERBOSE', "I've said too much"]
 
+    assert logging.TRACE == 5
     log.trace("But I haven't said enough")
     assert log.last() == ['TRACE', "But I haven't said enough"]
+
 
 def test_standards_suppressed(logging, log):
     """
     Ensure that the suppressed log level includes
-    the suppressed exception
+    the suppressed exception.
     """
     add_standards(logging)
 
@@ -34,3 +46,11 @@ def test_standards_suppressed(logging, log):
     assert lines.startswith('SUPPRESSED:')
     assert 'Exception: Suppress this' in lines
 
+
+def test_standards_suppressed_is_not_warn(logging, log):
+    """
+    Ensure that the new SUPPRESSED level does not collide with the
+    existing python WARN level.
+    """
+    add_standards(logging)
+    assert logging.SUPPRESSED == logging.WARN + 1


### PR DESCRIPTION
- Changed SUPPRESSED level to not be the same as WARN.
- Added extra syslog severity levels. It felt weird to say this library
  provided standard levels but didn't incorporate the syslog severities.
- Updated tests and added a couple.
- Made some lint and formatting tweaks.
- Added more detail to the README regarding standard levels.

During some testing I noticed that when using the logging-level standards, the new level SUPPRESSED was colliding with the existing level WARN. This manifests when logging as the level name being changed from WARN to SUPPRESSED. This seemed like a very bad idea to have all WARN messages be converted to SUPPRESSED, so I bumped the SUPPRESSED level by 1.
